### PR TITLE
Fix release-key

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -43,7 +43,6 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             signingConfig signingConfigs.release
-            debuggable false
         }
         debug {
             testCoverageEnabled true


### PR DESCRIPTION
Please accept quickly, it's a one liner to make release work again after a bad merge...
## Pull reviewers stats
Stats for the last 180 days:
|                                                                                                                                                                 | User            | Total reviews | Median time to review                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | Total comments |
| --------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------- | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
| <a href="https://github.com/so7fie"><img src="https://avatars.githubusercontent.com/u/10992808?v=4" width="20"></a>                                             | so7fie          | 29            | [13h 38m](https://app.flowwer.dev/charts/review-time/~(u~(i~'10992808~n~'so7fie)~p~180~r~(~(d~'qsmoye~t~'1g9l)~(d~'qson7e~t~'6g7)~(d~'qson80~t~'6gt)~(d~'qt1j6b~t~'wjg)~(d~'qt07rb~t~'4hjd)~(d~'qt06zc~t~'1ytf)~(d~'qsi275~t~'1yxs)~(d~'qsxwcl~t~'ht38)~(d~'qt1jzy~t~'1d2y)~(d~'qt285i~t~'3fw)~(d~'qs6mfb~t~'7b7e)~(d~'qs7tjn~t~'1500)~(d~'qsi0yg~t~'676f)~(d~'qpuy0b~t~'1v)~(d~'qqew7j~t~'2pkp)~(d~'qqf92s~t~'32fy)~(d~'qqjbho~t~'1ux)~(d~'qq0t0v~t~'5m7q)~(d~'qq0t2c~t~'5m97)~(d~'qq0p5z~t~'5hby)~(d~'qqy5l4~t~'5im1)~(d~'qrnshx~t~'193)~(d~'qq7qp0~t~'hf)~(d~'qrm6v4~t~'6ai)~(d~'qqkh75~t~'dr0)~(d~'qqrud7~t~'7qx2)~(d~'qr8kh3~t~'1kfr)~(d~'qrm9jc~t~'1npk)~(d~'qrmbez~t~'1ls)~(d~'qrpf7u~t~'11ut)~(d~'qrr5wv~t~'1e1c)~(d~'qs7udr~t~'12hc)~(d~'qs83lz~t~'8nr)~(d~'qs131e~t~'ghj)~(d~'qs1322~t~'gi7)~(d~'qs2ves~t~'18k)~(d~'qsomvk~t~'53m)~(d~'qsra8x~t~'hn6)~(d~'qsrail~t~'muw)~(d~'qrxija~t~'1azf)~(d~'qrxjn8~t~'1c3d)~(d~'qryfmg~t~'k5v)~(d~'qrygrv~t~'lba)~(d~'qrygwl~t~'lg0)~(d~'qtgafe~t~'rgf))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | **60**         |
| <a href="https://github.com/Snowflake8"><img src="https://avatars.githubusercontent.com/u/44499990?v=4" width="20"></a>                                         | Snowflake8      | 27            | [7h 23m](https://app.flowwer.dev/charts/review-time/~(u~(i~'44499990~n~'Snowflake8)~p~180~r~(~(d~'qsybaj~t~'9bt1)~(d~'qt06zp~t~'4grr)~(d~'qt0vi6~t~'55a8)~(d~'qt23cw~t~'khx)~(d~'qsatcu~t~'rli)~(d~'qrz0il~t~'tz)~(d~'qpt3s9~t~'2zf8)~(d~'qqjlvf~t~'b)~(d~'qqxzb3~t~'ikt)~(d~'qqdm38~t~'1fge)~(d~'qq6ncv~t~'8609)~(d~'qq8el9~t~'y2h)~(d~'qqjh1g~t~'gox)~(d~'qqjh87~t~'7lg)~(d~'qpx29n~t~'1vgi)~(d~'qq0q7g~t~'5jeb)~(d~'qq6k9y~t~'8hk)~(d~'qq6kh9~t~'8ov)~(d~'qq6r5v~t~'6b)~(d~'qqsnpq~t~'qn)~(d~'qro2s6~t~'666)~(d~'qrm4bb~t~'1ljt)~(d~'qrnhv0~t~'7)~(d~'qrkbo5~t~'88t)~(d~'qrm4eh~t~'1rq)~(d~'qrz0hs~t~'27o6)~(d~'qs396k~t~'f0c)~(d~'qrzb49~t~'3lg2)~(d~'qsasiz~t~'5yol)~(d~'qsbj9i~t~'6pf4)~(d~'qsp2w6~t~'d)~(d~'qshau1~t~'19dg)~(d~'qtbd3y~t~'43)~(d~'qtgthr~t~'31k2)~(d~'qtt97x~t~'c0))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | 55             |
| <a href="https://github.com/Huntsekkern"><img src="https://avatars.githubusercontent.com/u/44240415?v=4" width="20"></a>                                        | Huntsekkern     | 30            | [**6h 15m**](https://app.flowwer.dev/charts/review-time/~(u~(i~'44240415~n~'Huntsekkern)~p~180~r~(~(d~'qsvqgj~t~'6qz1)~(d~'qt1jgc~t~'wth)~(d~'qsvu6v~t~'x8x)~(d~'qt24yw~t~'1xeb)~(d~'qt2icu~t~'816)~(d~'qt3udr~t~'gj)~(d~'qsbchv~t~'hml)~(d~'qscdmi~t~'688)~(d~'qsdcs5~t~'lp3)~(d~'qrmbxz~t~'1bu)~(d~'qrmc41~t~'1hw)~(d~'qsbhva~t~'4tbn)~(d~'qsbjxk~t~'cx)~(d~'qpumtn~t~'1745)~(d~'qpt0zy~t~'2wmx)~(d~'qpt88n~t~'33vm)~(d~'qptd1d~t~'29r)~(d~'qptd3y~t~'2cc)~(d~'qqjij5~t~'i6m)~(d~'qq8faa~t~'qv)~(d~'qq8fiz~t~'bv)~(d~'qpt4tp~t~'2b1)~(d~'qpuo7b~t~'mk)~(d~'qq6uip~t~'3j5)~(d~'qrs0pv~t~'3yyp)~(d~'qrvgff~t~'1lvl)~(d~'qrihqg~t~'1wf3)~(d~'qrm9wa~t~'17x)~(d~'qrma4k~t~'1g7)~(d~'qrmajv~t~'1vi)~(d~'qrni3f~t~'15)~(d~'qqkomy~t~'z8i)~(d~'qqkozj~t~'zl3)~(d~'qqkp4h~t~'zq1)~(d~'qqvo8r~t~'14d)~(d~'qrmb5j~t~'1cc)~(d~'qs85j9~t~'al1)~(d~'qrwzfg~t~'6lu)~(d~'qs858h~t~'3be3)~(d~'qsvrbx~t~'y7p)~(d~'qsvqq1~t~'532c)~(d~'qryy4h~t~'12nw)~(d~'qryx5p~t~'ah5)~(d~'qsn1ou~t~'3hvc)~(d~'qtff6r~t~'m)~(d~'qtfe60~t~'hck)~(d~'qtipnq~t~'2avm))))                                                                                                                                                                                                                                                                                                                                                                                                                                                       | 54             |
| <a href="https://github.com/RaulinN"><img src="https://avatars.githubusercontent.com/u/44499915?u=c029696ff2de0902f905fbf35188359e94e08d88&v=4" width="20"></a> | RaulinN         | 32            | [7h 45m](https://app.flowwer.dev/charts/review-time/~(u~(i~'44499915~n~'RaulinN)~p~180~r~(~(d~'qt3hia~t~'1cpm)~(d~'qsb2b4~t~'7fu)~(d~'qsciv8~t~'j)~(d~'qsb2ae~t~'2k2)~(d~'qsc5gk~t~'az)~(d~'qsb1ye~t~'1072)~(d~'qptcqf~t~'1yt)~(d~'qpq5rb~t~'5xjz)~(d~'qqr6wy~t~'aju)~(d~'qreyev~t~'f)~(d~'qqhz4w~t~'87bj)~(d~'qq73x3~t~'8mkh)~(d~'qq821x~t~'lj5)~(d~'qq73ig~t~'jy6)~(d~'qq7vmj~t~'1t5)~(d~'qpuwak~t~'8pt)~(d~'qq73am~t~'28)~(d~'qrryuq~t~'428q)~(d~'qrrz93~t~'42n3)~(d~'qrs0cu~t~'3ylo)~(d~'qrni37~t~'x)~(d~'qq7qbn~t~'1bz)~(d~'qqj0lo~t~'u5)~(d~'qqjmtu~t~'n2b)~(d~'qrm5d5~t~'2qe)~(d~'qrrzpp~t~'3mco)~(d~'qrsjsf~t~'7tp)~(d~'qsb1c8~t~'sra)~(d~'qtnp1h~t~'50f2)~(d~'qt3m50~t~'11g)~(d~'qtdr1i~t~'18om)~(d~'qtdpp8~t~'4cnp)~(d~'qtnoui~t~'2vgc)~(d~'qtdq1w~t~'2d21)~(d~'qtfq0z~t~'m)~(d~'qtdqyu~t~'x1o)~(d~'qtrtsa~t~'cea)~(d~'qtru7o~t~'2x0i)~(d~'qtrtvf~t~'3jlf))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | 45             |
| <a href="https://github.com/DGoedtkindtEPFL"><img src="https://avatars.githubusercontent.com/u/61052800?v=4" width="20"></a>                                    | DGoedtkindtEPFL | **39**        | [15h 13m](https://app.flowwer.dev/charts/review-time/~(u~(i~'61052800~n~'DGoedtkindtEPFL)~p~180~r~(~(d~'qsutl8~t~'2l0)~(d~'qt1duk~t~'169z)~(d~'qsp2e9~t~'8z4w)~(d~'qt1ec8~t~'17f8)~(d~'qt9ofl~t~'5uid)~(d~'qscac2~t~'442)~(d~'qs0a3d~t~'xnt)~(d~'qpuy16~t~'2q)~(d~'qpuoy1~t~'co)~(d~'qpup0b~t~'19at)~(d~'qplma9~t~'1e2x)~(d~'qpuugt~t~'am9h)~(d~'qqrtyv~t~'xlr)~(d~'qqjmgc~t~'dy)~(d~'qqjjxz~t~'9s4m)~(d~'qq9yj2~t~'1i5c)~(d~'qq6s0w~t~'8gm)~(d~'qq6rfm~t~'fn8)~(d~'qrnxgy~t~'1wd)~(d~'qrsrti~t~'4q2c)~(d~'qqxoq1~t~'21ln)~(d~'qqioj1~t~'2x8a)~(d~'qqionj~t~'2xcs)~(d~'qqioou~t~'2xe3)~(d~'qqipcq~t~'2y1z)~(d~'qqru2n~t~'7qmi)~(d~'qrm4pz~t~'1iw7)~(d~'qrm4za~t~'1j5i)~(d~'qrm5eq~t~'1jky)~(d~'qrmfv4~t~'1u1c)~(d~'qrmhyq~t~'1cp)~(d~'qs2og9~t~'21we)~(d~'qrxjta~t~'qzo)~(d~'qrxk77~t~'25m)~(d~'qryk8c~t~'58f)~(d~'qs2oux~t~'1k7w)~(d~'qsa5hg~t~'1a0u)~(d~'qsa8mh~t~'1j)~(d~'qsa8rj~t~'6l)~(d~'qsa8tq~t~'8s)~(d~'qsam7t~t~'dmv)~(d~'qsogu4~t~'17yr)~(d~'qs0amr~t~'pgk)~(d~'qs0aqu~t~'pkn)~(d~'qs44fc~t~'19vi)~(d~'qsovo9~t~'3qz)~(d~'qryv6t~t~'8i9)~(d~'qtio32~t~'1q)~(d~'qtefvx~t~'u8z)~(d~'qtefzp~t~'ucr)~(d~'qtegm0~t~'uz2)~(d~'qsmngd~t~'33mv)~(d~'qtomtk~t~'69)~(d~'qtewwa~t~'23p)~(d~'qtgalr~t~'rms)~(d~'qtnp2h~t~'35a1)~(d~'qtq1kd~t~'5hrx)~(d~'qtrdjr~t~'10o)~(d~'qtrdky~t~'11v)~(d~'qtrdlj~t~'12g)~(d~'qtrx3k~t~'fpk)~(d~'qtq227~t~'b0ic)~(d~'qtnwp1~t~'a4rc)~(d~'qtnwr2~t~'a4td)~(d~'qtnybu~t~'a6e5)~(d~'qtoc0u~t~'ak35)~(d~'qtrxr1~t~'e5tc)~(d~'qtq0xr~t~'1qnr)~(d~'qttags~t~'q)))) | 44             |
| <a href="https://github.com/Laniakea1999"><img src="https://avatars.githubusercontent.com/u/43450242?v=4" width="20"></a>                                       | Laniakea1999    | 21            | [12h 59m](https://app.flowwer.dev/charts/review-time/~(u~(i~'43450242~n~'Laniakea1999)~p~180~r~(~(d~'qsl5yv~t~'52pi)~(d~'qsc6gz~t~'coy)~(d~'qpupsq~t~'d4)~(d~'qqeyk1~t~'2rx7)~(d~'qq7oa5~t~'1n)~(d~'qrmbac~t~'1h5)~(d~'qs2ml9~t~'201e)~(d~'qrx80e~t~'f6s)~(d~'qrzab0~t~'vb3)~(d~'qsc6o4~t~'7ctq)~(d~'qsoj15~t~'1a5s)~(d~'qsopgk~t~'1kf)~(d~'qrx7lz~t~'1024)~(d~'qtd61v~t~'9by1)~(d~'qtd55e~t~'msi)~(d~'qtd42x~t~'3r1e)~(d~'qtd3u7~t~'1quc)~(d~'qtd4xz~t~'b0t)~(d~'qtruu7~t~'2xn1)~(d~'qtrw2v~t~'cuj0)~(d~'qtt9rp~t~'m))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | 15             |